### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,20 +43,20 @@
     "vue": "^2.7.0 || ^3.4.0"
   },
   "devDependencies": {
-    "@antfu/eslint-config": "latest",
+    "@antfu/eslint-config": "^9.1.0",
     "@types/jsdom": "28.0.3",
     "@types/node": "24.13.2",
     "@vitejs/plugin-vue": "6.0.7",
     "@vitest/coverage-v8": "4.1.10",
     "@vue/test-utils": "2.4.11",
-    "eslint": "latest",
+    "eslint": "^10.6.0",
     "jsdom": "29.1.1",
     "nano-staged": "1.0.2",
-    "simple-git-hooks": "latest",
+    "simple-git-hooks": "^2.13.1",
     "tsdown": "0.22.3",
-    "typescript": "latest",
-    "vite": "latest",
-    "vitest": "latest",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3",
+    "vitest": "^4.1.10",
     "vue": "3.5.39"
   },
   "simple-git-hooks": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,10 +6,10 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "@vitejs/plugin-vue": "latest",
+    "@vitejs/plugin-vue": "^6.0.7",
     "@vueuse/core": "^14.0.0",
     "stream-vue": "latest",
-    "vite": "latest",
-    "vue": "latest"
+    "vite": "^8.1.3",
+    "vue": "^3.5.39"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     devDependencies:
       '@antfu/eslint-config':
-        specifier: latest
+        specifier: ^9.1.0
         version: 9.1.0(@typescript-eslint/rule-tester@8.60.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.62.0(typescript@6.0.3))(@typescript-eslint/utils@8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.10)
       '@types/jsdom':
         specifier: 28.0.3
@@ -30,7 +30,7 @@ importers:
         specifier: 2.4.11
         version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       eslint:
-        specifier: latest
+        specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
       jsdom:
         specifier: 29.1.1
@@ -39,19 +39,19 @@ importers:
         specifier: 1.0.2
         version: 1.0.2
       simple-git-hooks:
-        specifier: latest
+        specifier: ^2.13.1
         version: 2.13.1
       tsdown:
         specifier: 0.22.3
         version: 0.22.3(typescript@6.0.3)
       typescript:
-        specifier: latest
+        specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: latest
+        specifier: ^8.1.3
         version: 8.1.3(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
-        specifier: latest
+        specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
       vue:
         specifier: 3.5.39
@@ -60,7 +60,7 @@ importers:
   playground:
     dependencies:
       '@vitejs/plugin-vue':
-        specifier: latest
+        specifier: ^6.0.7
         version: 6.0.7(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
       '@vueuse/core':
         specifier: ^14.0.0
@@ -69,10 +69,10 @@ importers:
         specifier: link:..
         version: link:..
       vite:
-        specifier: latest
+        specifier: ^8.1.3
         version: 8.1.3(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)
       vue:
-        specifier: latest
+        specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
 
 packages:


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration